### PR TITLE
Fixed images pull to request bug

### DIFF
--- a/Blocstagram/Blocstagram/BLCDatasource.m
+++ b/Blocstagram/Blocstagram/BLCDatasource.m
@@ -95,7 +95,8 @@
         self.isRefreshing = YES;
 
         NSString *minID = [[self.mediaItems firstObject] idNumber];
-        NSDictionary *parameters = @{@"min_id": minID};
+        
+        NSDictionary *parameters = minID ? @{@"min_id": minID} : nil;
         
         [self populateDataWithParameters:parameters completionHandler:^(NSError *error) {
             self.isRefreshing = NO;


### PR DESCRIPTION
The issue came with setting NSString ***minID*** to the first object in our ***mediaItems*** array when the ***mediaItems*** array is empty. This ***minID*** value is then used to create a NSDictionary, ***parameters***. When this is a nil value, it causes a crash while creating the dictionary. 

I added a check to ensure that ***minID*** is present, and if not, to update our ***parameters*** to nil. This results in the entire feed being reloaded if the user has deleted all existing images and pulls to refresh. 